### PR TITLE
Add second argument to method in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Once you have a foreign connection you can now create migrations for the foreign
 ```ruby
 class CreatePost < ActiveRecord::Migration[5.0]
   def change
-    create_foreign_table :posts do |t|
+    create_foreign_table :posts, :foreign_server do |t|
       t.string :title
       t.text :body
     end


### PR DESCRIPTION
In documentation in the example of migration creating a new foreign table, there is only one argument, but according to the source code, there should be two arguments (https://github.com/ratdaddy/immigrate/blob/master/lib/immigrate/schema_statements.rb#L13)